### PR TITLE
feat: Add logLevel option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ MMKVModule constructor, `options` is required.
 - `id`: mmap id, `default: mmkv.default`[optional]
 - `multiProcess`: Enable multi process, `default: false`[optional]
 - `cryptKey`: encryption key[optional]
+- `logLevel`: log level, `default: info`[optional]
 
 ### setString: (key: string, value: string) => boolean | undefined;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,10 @@ declare interface MMKVModuleOptions {
    * encryption key
    */
   cryptKey?: string;
+  /**
+   * log level, default: info
+   */
+  logLevel?: "debug" | "info" | "warning" | "error" | "none";
 }
 
 declare class MMKVModule {


### PR DESCRIPTION
## Description 

This PR introduces a new option to `MMKVModuleOptions` in order to allow the user to control the log level of an MMKV instance.  By default the log level is set to Info, which is the same default default level MMKV in all platforms.

## Test Plan

**Using demo/demo.js:**
 
Not providing a `logLevel` should maintain the current behavior 
```
const instance = new MMKVModule({
  rootDir: path.join(__dirname, "./mmkv"),  
});
```
Console output:
```
[I] <MMKV.cpp:160::initialize> version v1.2.16, page size 16384, arch arm64-v8a
[I] <MMKV.cpp:203::initializeMMKV> root dir: /Users/gabriel/Workspace/node-mmkv/demo/mmkv
[I] <MMKV.cpp:230::mmkvWithID> prepare to load com.node.mmkv (id com.node.mmkv) from rootPath /Users/gabriel/Workspace/node-mmkv/demo/mmkv
[I] <MemoryFile.cpp:97::open> open fd[0x14], /Users/gabriel/Workspace/node-mmkv/demo/mmkv/com.node.mmkv
[I] <MemoryFile.cpp:97::open> open fd[0x15], /Users/gabriel/Workspace/node-mmkv/demo/mmkv/com.node.mmkv.crc
```


Setting `logLevel` to warning should not show `[I]` logs
```
const instance = new MMKVModule({
  rootDir: path.join(__dirname, "./mmkv"), 
  logLevel: "warning",
});
```
Console output:
```
```